### PR TITLE
sj-create a placeholder page at the url /myreviews

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,6 +15,8 @@ import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 
+import MyReviewsIndexPage from "main/pages/MyReviews/MyReviewsIndexPage";
+
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
@@ -94,6 +96,11 @@ function App() {
               path="/placeholder/create"
               element={<PlaceholderCreatePage />}
             />
+          </>
+        )}
+        {hasRole(currentUser, "ROLE_USER") && (
+          <>
+            <Route exact path="/myreviews" element={<MyReviewsIndexPage />} />
           </>
         )}
       </Routes>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -69,6 +69,9 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/placeholder">
                     Placeholder
                   </Nav.Link>
+                  <Nav.Link as={Link} to="/myreviews">
+                    My Reviews
+                  </Nav.Link>
                 </>
               ) : (
                 <></>

--- a/frontend/src/main/pages/MyReviews/MyReviewsIndexPage.js
+++ b/frontend/src/main/pages/MyReviews/MyReviewsIndexPage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MyReviewsIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>This page will eventually show all reviews entered by the user</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/pages/MyReviews/MyReviewsIndexPage.test.js
+++ b/frontend/src/tests/pages/MyReviews/MyReviewsIndexPage.test.js
@@ -8,7 +8,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-describe("PlaceholderIndexPage tests", () => {
+describe("MyReviewsIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
   const setupUserOnly = () => {

--- a/frontend/src/tests/pages/MyReviews/MyReviewsIndexPage.test.js
+++ b/frontend/src/tests/pages/MyReviews/MyReviewsIndexPage.test.js
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import MyReviewsIndexPage from "main/pages/MyReviews/MyReviewsIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("PlaceholderIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MyReviewsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText(
+      "This page will eventually show all reviews entered by the user",
+    );
+
+    // assert
+    expect(
+      screen.getByText(
+        "This page will eventually show all reviews entered by the user",
+      ),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Merge before #25 and #26 

Closes #16 

This pull request creates a placeholder at the url /myreviews that will eventually display the reviews the currently logged in user has created.

To verify, login to dokku link:
https://proj-dining-f24-13-clevermonkey16-dev.dokku-13.cs.ucsb.edu

Click on the "My Reviews" tab at the top, then verify that the text says "This page will eventually show all reviews entered by the user".

<img width="1432" alt="Screenshot 2024-11-16 at 4 19 01 PM" src="https://github.com/user-attachments/assets/a2a6e2bf-a06f-49b3-928a-ab258b80b4df">
