### PR TITLE
sj-add placeholder page /moderate

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,6 +17,8 @@ import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 
 import MyReviewsIndexPage from "main/pages/MyReviews/MyReviewsIndexPage";
 
+import ModerateIndexPage from "main/pages/Moderate/ModerateIndexPage";
+
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
@@ -101,6 +103,11 @@ function App() {
         {hasRole(currentUser, "ROLE_USER") && (
           <>
             <Route exact path="/myreviews" element={<MyReviewsIndexPage />} />
+          </>
+        )}
+        {hasRole(currentUser, "ROLE_ADMIN") && (
+          <>
+            <Route exact path="/moderate" element={<ModerateIndexPage />} />
           </>
         )}
       </Routes>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -50,13 +50,20 @@ export default function AppNavbar({
           <Navbar.Collapse className="justify-content-between">
             <Nav className="mr-auto">
               {hasRole(currentUser, "ROLE_ADMIN") && (
-                <NavDropdown
-                  title="Admin"
-                  id="appnavbar-admin-dropdown"
-                  data-testid="appnavbar-admin-dropdown"
-                >
-                  <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
-                </NavDropdown>
+                <>
+                  <NavDropdown
+                    title="Admin"
+                    id="appnavbar-admin-dropdown"
+                    data-testid="appnavbar-admin-dropdown"
+                  >
+                    <NavDropdown.Item href="/admin/users">
+                      Users
+                    </NavDropdown.Item>
+                  </NavDropdown>
+                  <Nav.Link as={Link} to="/moderate">
+                    Moderate
+                  </Nav.Link>
+                </>
               )}
               {currentUser && currentUser.loggedIn ? (
                 <>

--- a/frontend/src/main/pages/Moderate/ModerateIndexPage.js
+++ b/frontend/src/main/pages/Moderate/ModerateIndexPage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ModerateIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>This page will eventually show the moderation controls</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/pages/Moderate/ModerateIndexPage.test.js
+++ b/frontend/src/tests/pages/Moderate/ModerateIndexPage.test.js
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import ModerateIndexPage from "main/pages/Moderate/ModerateIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("MyReviewsIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ModerateIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText(
+      "This page will eventually show the moderation controls",
+    );
+
+    // assert
+    expect(
+      screen.getByText(
+        "This page will eventually show the moderation controls",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/Moderate/ModerateIndexPage.test.js
+++ b/frontend/src/tests/pages/Moderate/ModerateIndexPage.test.js
@@ -8,7 +8,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-describe("MyReviewsIndexPage tests", () => {
+describe("ModerateIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
   const setupUserOnly = () => {


### PR DESCRIPTION
Merge after #24 and before #26

Closes #21 

Adds a placeholder tab at the address /moderate that will eventually have moderator controls.

To verify, go to the dokku and login with an admin email:
https://proj-dining-f24-13-clevermonkey16-dev.dokku-13.cs.ucsb.edu

Check that the Moderate tab is there at the top. Click on it, and check that it has the text "This page will eventually show the moderation controls".
<img width="1431" alt="Screenshot 2024-11-16 at 10 51 31 PM" src="https://github.com/user-attachments/assets/79ebe8e6-576e-4598-8540-bc56dd7b455b">

Then, log out, and then log into a non-admin email. Check that the Moderate tab is not accessible.
<img width="1425" alt="Screenshot 2024-11-16 at 10 51 40 PM" src="https://github.com/user-attachments/assets/2363cc9f-9569-4b22-8c0f-d032dcb72593">

