### PR TITLE
dq-ReviewBackend get by user endpoint + tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewsController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewsController.java
@@ -56,6 +56,20 @@ public class ReviewsController extends ApiController {
     }
 
     /**
+     * List all reviews created by a specific user
+     * 
+     * @return an iterable of Review
+     */
+    @Operation(summary= "List all reviews created by a specific user")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public Iterable<Review> getReviewsByUser(
+        @Parameter(name="userId") @RequestParam long userId) {
+        Iterable<Review> reviews = reviewsRepository.findAllByReviewerId(userId);
+        return reviews;
+    }
+
+    /**
      * Create a new review
      * 
      * @param itemId            id of item in DiningCommonsMenuItem table

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewsControllerTests.java
@@ -212,7 +212,7 @@ public class ReviewsControllerTests extends ControllerTestCase {
                                 .dateServed(ldt1)
                                 .stars(5)
                                 .reviewText("very good")
-                                .status("Awaiting Approval")
+                                .status("Awaiting Moderation")
                                 .createdDate(ldt1)
                                 .lastEditedDate(ldt1)
                                 .build();


### PR DESCRIPTION
Closes #12 

Go to https://dining-st4lemon.dokku-13.cs.ucsb.edu 

- On Swagger, verify that a get endpoint exists for userId
![dininggetuser](https://github.com/user-attachments/assets/c95d487a-021c-4678-89bd-e237e7d0aeaf)
- Get all reviews with /api/reviews/all, check what reviewerIds exist in the reviews
- Pick a reviewerId x, check that /api/reviews?userId=x returns all reviews by that user

- [ ] Logged out user cannot get by user id
- [ ] Logged in user/admin user can get reviews by user id
- [ ] All reviews made by the given user are returned 
- [ ] Only reviews made by the given user are returned
