### PR TITLE
dq-ReviewBackend GET reviews needing moderation, PUT endpoints to update a user's review and moderate a review

### DIFF
--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewsController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewsController.java
@@ -78,7 +78,7 @@ public class ReviewsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/needsmoderation")
     public Iterable<Review> getReviewsNeedingModeration() {
-        Iterable<Review> reviews = reviewsRepository.findAllByStatus("Awaiting Approval");
+        Iterable<Review> reviews = reviewsRepository.findAllByStatus("Awaiting Moderation");
         return reviews;
     }
 

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewsController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewsController.java
@@ -122,5 +122,62 @@ public class ReviewsController extends ApiController {
 
         return savedReview;
     }
+    
+    /**
+     * Update a single review
+     * 
+     * @param id        id of the review to update
+     * @param incoming  the new review
+     * @return the updated review object
+     */
+    @Operation(summary= "Update a single review")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PutMapping("/reviewer")
+    public Review updateReview(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid Review incoming) {
+            
+        Review review = reviewsRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Review.class, id));
+
+        review.setStars(incoming.getStars());
+        review.setReviewText(incoming.getReviewText());
+        review.setStatus("Awaiting Moderation");
+        review.setModId(null);
+        review.setModComments(null);
+        review.setLastEditedDate(LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS));
+
+        reviewsRepository.save(review);
+
+        return review;
+    }
+
+    /**
+     * Moderate a single review
+     * 
+     * @param id        id of the review to moderate
+     * @param incoming  the new review
+     * @return the updated review object
+     */
+    @Operation(summary= "Moderate a single review")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("/moderator")
+    public Review moderateReview(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid Review incoming) {
+
+
+        Review review = reviewsRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Review.class, id));
+
+        review.setStatus(incoming.getStatus());
+        review.setModComments(incoming.getModComments());
+        review.setModId(getCurrentUser().getUser().getId());
+        review.setLastEditedDate(LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS));
+
+        reviewsRepository.save(review);
+
+        return review;
+    }
 
 }

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewsController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewsController.java
@@ -33,6 +33,9 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
+import java.util.Arrays;
+import java.util.ArrayList;
+
 /**
  * This is a REST controller for Reviews
  */
@@ -181,7 +184,7 @@ public class ReviewsController extends ApiController {
         Review review = reviewsRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(Review.class, id));
         
-        if( !(incoming.getStatus().equals("Awaiting Moderation") || incoming.getStatus().equals("Approved") || incoming.getStatus().equals("Rejected")) ) {
+        if( !incoming.getStatus().matches("Approved|Awaiting Approval|Rejected") ) {
             throw new IllegalArgumentException("Status must be 'Awaiting Moderation', 'Approved', or 'Rejected'");
         } 
 

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewsController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewsController.java
@@ -22,6 +22,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import org.springframework.http.HttpStatus;
 
 import jakarta.validation.Valid;
 
@@ -41,6 +45,13 @@ public class ReviewsController extends ApiController {
 
     @Autowired
     ReviewRepository reviewsRepository;
+
+    
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalArgumentException.class)
+    public void handleIllegalArgumentException() {
+
+    }
 
     /**
      * List all reviews
@@ -169,6 +180,10 @@ public class ReviewsController extends ApiController {
 
         Review review = reviewsRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(Review.class, id));
+        
+        if( !(incoming.getStatus().equals("Awaiting Moderation") || incoming.getStatus().equals("Approved") || incoming.getStatus().equals("Rejected")) ) {
+            throw new IllegalArgumentException("Status must be 'Awaiting Moderation', 'Approved', or 'Rejected'");
+        } 
 
         review.setStatus(incoming.getStatus());
         review.setModComments(incoming.getModComments());

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewsController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewsController.java
@@ -70,6 +70,19 @@ public class ReviewsController extends ApiController {
     }
 
     /**
+     * List all reviews needing moderation
+     * 
+     * @return an iterable of Review
+     */
+    @Operation(summary= "List all reviews needing moderation")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/needsmoderation")
+    public Iterable<Review> getReviewsNeedingModeration() {
+        Iterable<Review> reviews = reviewsRepository.findAllByStatus("Awaiting Approval");
+        return reviews;
+    }
+
+    /**
      * Create a new review
      * 
      * @param itemId            id of item in DiningCommonsMenuItem table

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewsController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewsController.java
@@ -184,8 +184,10 @@ public class ReviewsController extends ApiController {
         Review review = reviewsRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(Review.class, id));
         
-        if( !incoming.getStatus().matches("Approved|Awaiting Approval|Rejected") ) {
-            throw new IllegalArgumentException("Status must be 'Awaiting Moderation', 'Approved', or 'Rejected'");
+        ArrayList<String> validStatus = new ArrayList<>(Arrays.asList("Approved", "Awaiting Moderation", "Rejected"));
+
+        if( !validStatus.contains(incoming.getStatus()) ) {
+            throw new IllegalArgumentException("Status must be one of: " + validStatus);
         } 
 
         review.setStatus(incoming.getStatus());

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewsControllerTests.java
@@ -540,7 +540,7 @@ public class ReviewsControllerTests extends ControllerTestCase {
                 verify(reviewsRepository, times(1)).findById(67L);
                 Optional<IllegalArgumentException> except = Optional.ofNullable((IllegalArgumentException) response.getResolvedException());
                 assertTrue(except.isPresent());
-                except.ifPresent( (e) -> assertEquals(e.getMessage(), "Status must be 'Awaiting Moderation', 'Approved', or 'Rejected'"));
+                except.ifPresent( (e) -> assertEquals(e.getMessage(), "Status must be one of: [Approved, Awaiting Moderation, Rejected]"));
 
         }
 

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewsControllerTests.java
@@ -465,9 +465,9 @@ public class ReviewsControllerTests extends ControllerTestCase {
                                 .dateServed(ldt1)
                                 .stars(1)
                                 .reviewText("very bad")
-                                .status("Approved")
+                                .status("Rejected")
                                 .modId(1L)
-                                .modComments("good good")
+                                .modComments("not good")
                                 .createdDate(ldt1)
                                 .lastEditedDate(LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS))
                                 .build();

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewsControllerTests.java
@@ -262,7 +262,7 @@ public class ReviewsControllerTests extends ControllerTestCase {
                                 .dateServed(ldt1)
                                 .stars(5)
                                 .reviewText("very good")
-                                .status("Awaiting Approval")
+                                .status("Awaiting Moderation")
                                 .createdDate(ldt1)
                                 .lastEditedDate(ldt1)
                                 .build();
@@ -270,7 +270,7 @@ public class ReviewsControllerTests extends ControllerTestCase {
                 ArrayList<Review> expectedReviews = new ArrayList<>();
                 expectedReviews.add(reviews1);
 
-                when(reviewsRepository.findAllByStatus("Awaiting Approval")).thenReturn(expectedReviews);
+                when(reviewsRepository.findAllByStatus("Awaiting Moderation")).thenReturn(expectedReviews);
 
                 // act
                 MvcResult response = mockMvc.perform(get("/api/reviews/needsmoderation"))
@@ -278,7 +278,7 @@ public class ReviewsControllerTests extends ControllerTestCase {
 
                 // assert
 
-                verify(reviewsRepository, times(1)).findAllByStatus("Awaiting Approval");
+                verify(reviewsRepository, times(1)).findAllByStatus("Awaiting Moderation");
                 String expectedJson = mapper.writeValueAsString(expectedReviews);
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewsControllerTests.java
@@ -315,7 +315,6 @@ public class ReviewsControllerTests extends ControllerTestCase {
                 // arrange
 
                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
-                LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
 
                 Review reviewOrig = Review.builder()
                                 .reviewerId(1)
@@ -323,7 +322,9 @@ public class ReviewsControllerTests extends ControllerTestCase {
                                 .dateServed(ldt1)
                                 .stars(5)
                                 .reviewText("very good")
-                                .status("Awaiting Moderation")
+                                .status("Approved")
+                                .modId(3L)
+                                .modComments("good review")
                                 .createdDate(ldt1)
                                 .lastEditedDate(ldt1)
                                 .build();
@@ -405,7 +406,6 @@ public class ReviewsControllerTests extends ControllerTestCase {
                 // arrange
 
                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
-                LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
 
                 Review reviewOrig = Review.builder()
                                 .reviewerId(1)


### PR DESCRIPTION
Closes #15 #18  (combined into one pull request to make reviewing easier)

Go to: https://dining-st4lemon.dokku-13.cs.ucsb.edu

- Three new endpoints exist: POST /api/reviews/reviewer, POST /api/reviews/moderator, GET /api/reviews/needsmoderation:
![diningmoderate](https://github.com/user-attachments/assets/254f668a-2020-4e09-a847-2ef1886ad488)
![diningupdate](https://github.com/user-attachments/assets/a60145ef-b9cc-48ca-9074-de455728f562)
![dininggetmoderation](https://github.com/user-attachments/assets/8b7a5162-dc6f-4eb2-8d35-b08599402e88)

- [ ] GET /api/reviews/needsmoderation displays all reviews needing moderation (if none exist, post a new review and verify it shows up).
- [ ] POST /api/reviews/moderator allows an admin user to approve/reject a review, and add comments. 
- [ ] Moderating a review correctly uses the moderator's user id as ModID.
- [ ] Moderated reviews do not show up in GET /api/reviews/needsmoderation.
- [ ] POST /api/reviews/reviewer allows a user to edit a review's star rating and review text.
- [ ] Editing an approved/rejected review resets the approval status to "Awaiting Approval", and deletes mod id and comments.
- [ ] All endpoints update lastEditedDate with the current time.
